### PR TITLE
Fix configuration cache incompatibilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,25 +58,9 @@ gradlePlugin {
     }
 }
 
-final changelogTask = tasks.register('changelog') {
-    RegularFileProperty outputFile = objects.fileProperty().convention(layout.buildDirectory.file('changelog.txt'))
-    it.outputs.file(outputFile).withPropertyName('output changelog file')
-
+final changelogTask = tasks.register('changelog', GenerateChangelogTask) {
     it.description = 'Generates a commit changelog using the git CLI command'
-    it.doLast {
-        try {
-            outputFile.get().asFile.withOutputStream { output ->
-                project.exec { ExecSpec spec ->
-                    // TODO: limit to last reachable tag?
-                    spec.commandLine('git', 'log', '--no-show-signature', '--no-color',
-                            '--pretty=%h% (describe:tags=true:abbrev) (%aN) %s')
-                            .standardOutput(output)
-                }.assertNormalExitValue().rethrowFailure()
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to generate changelog; check if 'git' is on the PATH", e)
-        }
-    }
+    it.changelogFile.set(layout.buildDirectory.file('changelog.txt'))
 }
 
 tasks.named('assemble') {
@@ -141,11 +125,45 @@ publishing {
     }
 }
 
-tasks.register("configureTeamCity") {
-    // Print marker lines into the log which configure the pipeline
-    doLast {
-        project.getLogger().lifecycle("Setting project variables and parameters.")
-        println "##teamcity[buildNumber '${project.version}']"
-        println "##teamcity[setParameter name='env.PUBLISHED_JAVA_ARTIFACT_VERSION' value='${project.version}']"
+final versionProvider = providers.provider { project.version?.toString() }
+tasks.register("configureTeamCity", ConfigureTeamCity) {
+    version.set(versionProvider)
+}
+
+abstract class ConfigureTeamCity extends DefaultTask {
+    @Input
+    abstract Property<String> getVersion()
+
+    @TaskAction
+    void doAction() {
+        final versionString = version.get()
+        // Print marker lines into the log which configure the pipeline
+        logger.lifecycle("Setting project variables and parameters.")
+        println "##teamcity[buildNumber '${versionString}']"
+        println "##teamcity[setParameter name='env.PUBLISHED_JAVA_ARTIFACT_VERSION' value='${versionString}']"
+    }
+}
+
+abstract class GenerateChangelogTask extends DefaultTask {
+    @OutputFile
+    abstract RegularFileProperty getChangelogFile()
+
+    @javax.inject.Inject // This might look like a compile error in IDE, but it actually compiles okay
+    abstract ExecOperations getExecOperations()
+
+    @TaskAction
+    void generate() {
+        try {
+            changelogFile.get().asFile.withOutputStream { output ->
+                execOperations.exec { ExecSpec spec ->
+                    // TODO: limit to last reachable tag?
+                    spec.commandLine('git', 'log', '--no-show-signature', '--no-color',
+                            '--pretty=%h% (describe:tags=true:abbrev) (%aN) %s')
+                    spec.standardOutput(output)
+                }.assertNormalExitValue().rethrowFailure()
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate changelog; check if 'git' is on the PATH", e)
+        }
     }
 }

--- a/src/main/groovy/net/neoforged/gradleutils/ChangelogGenerationExtension.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/ChangelogGenerationExtension.groovy
@@ -5,13 +5,13 @@
 
 package net.neoforged.gradleutils
 
+import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
 
 import javax.inject.Inject
 
-// For some reason, annotating this as @CompileStatic causes the Groovy compiler to crash with StackOverflowError
-// TODO: investigate what in this class causes the Groovy compiler to crash when annotated with @CompileStatic
+@CompileStatic
 class ChangelogGenerationExtension {
     private final Project project
     private boolean registerAllPublications = true
@@ -23,17 +23,25 @@ class ChangelogGenerationExtension {
 
     void fromMergeBase() {
         ChangelogUtils.setupChangelogGeneration(project)
-        project.afterEvaluate(this::afterEvaluate)
+        // These shouldn't be project.afterEvaluate(this::afterEvaluate), otherwise the Groovy compiler crashes
+        // Don't know why, but it's just how it is
+        project.afterEvaluate {
+            afterEvaluate(project)
+        }
     }
 
     void fromTag(final String tag) {
         ChangelogUtils.setupChangelogGenerationFromTag(project, tag)
-        project.afterEvaluate(this::afterEvaluate)
+        project.afterEvaluate {
+            afterEvaluate(project)
+        }
     }
 
     void fromCommit(final String commit) {
         ChangelogUtils.setupChangelogGenerationFromCommit(project, commit)
-        project.afterEvaluate(this::afterEvaluate)
+        project.afterEvaluate {
+            afterEvaluate(project)
+        }
     }
 
     void disableAutomaticPublicationRegistration() {

--- a/src/main/groovy/net/neoforged/gradleutils/ChangelogUtils.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/ChangelogUtils.groovy
@@ -54,7 +54,7 @@ class ChangelogUtils {
      * @return A multiline changelog string.
      */
     static String generateChangelog(final File projectDirectory, final String repositoryUrl, final boolean justText) {
-        def git = Git.open(projectDirectory) //Grab git from the given project directory.
+        def git = GradleUtils.openGit(projectDirectory) //Grab git from the given project directory.
 
         def headCommit = getHead(git) //Grab the head commit.
         RevCommit logFromCommit = getMergeBaseCommit(git) //Grab the last merge base commit on the current branch.
@@ -77,7 +77,7 @@ class ChangelogUtils {
      * @return A multiline changelog string.
      */
     static String generateChangelog(final File projectDirectory, final String repositoryUrl, final boolean justText, final String sourceTag) {
-        def git = Git.open(projectDirectory) //Grab git from the given project directory.
+        def git = GradleUtils.openGit(projectDirectory) //Grab git from the given project directory.
 
         def tagMap = getTagToCommitMap(git) //Get the tag to commit map so that the beginning commit can be found.
         if (!tagMap.containsKey(sourceTag)) //Check if it even exists.
@@ -101,7 +101,7 @@ class ChangelogUtils {
      * @return A multiline changelog string.
      */
     static String generateChangelogFromCommit(final File projectDirectory, final String repositoryUrl, final boolean justText, final String commitHash) {
-        def git = Git.open(projectDirectory) //Grab git from the given project directory.
+        def git = GradleUtils.openGit(projectDirectory) //Grab git from the given project directory.
 
         def commit = getCommitFromId(git, ObjectId.fromString(commitHash)) //Grab the start commit.
         def headCommit = getHead(git) //Grab the current head commit.

--- a/src/main/groovy/net/neoforged/gradleutils/GitInfoValueSource.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GitInfoValueSource.groovy
@@ -1,0 +1,121 @@
+//file:noinspection UnstableApiUsage
+package net.neoforged.gradleutils
+
+import groovy.transform.CompileStatic
+import groovy.transform.Immutable
+import groovy.transform.PackageScope
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.errors.RepositoryNotFoundException
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+import javax.annotation.Nullable
+
+@PackageScope
+@CompileStatic
+interface GitInfoValueSource extends ValueSource<GitInfo, Parameters> {
+    interface Parameters extends ValueSourceParameters {
+        DirectoryProperty getWorkingDirectory()
+
+        SetProperty<String> getTagFilters()
+    }
+
+    @Override
+    default GitInfo obtain() {
+        try (Repository repo = new FileRepositoryBuilder().findGitDir(parameters.workingDirectory.get().asFile).build()) {
+            final git = Git.wrap(repo)
+
+            final filters = parameters.tagFilters.get().<String> toArray(new String[0])
+            final tag = git.describe().setLong(true).setTags(true).setMatch(filters).call()
+            final desc = GradleUtils.rsplit(tag, '-', 2) ?: ['0.0', '0', '00000000']
+            final head = git.repository.exactRef('HEAD')
+            final String longBranch = head.symbolic ? head?.target?.name : null
+            // matches Repository.getFullBranch() but returning null when on a detached HEAD
+
+            Map<String, String> gitInfoMap = [:]
+            gitInfoMap.dir = repo.getDirectory().parentFile.absolutePath
+            gitInfoMap.tag = desc[0]
+            if (gitInfoMap.tag.startsWith("v") && gitInfoMap.tag.length() > 1 && gitInfoMap.tag.charAt(1).digit)
+                gitInfoMap.tag = gitInfoMap.tag.substring(1)
+            gitInfoMap.offset = desc[1]
+            gitInfoMap.hash = desc[2]
+            gitInfoMap.branch = longBranch != null ? Repository.shortenRefName(longBranch) : null
+            gitInfoMap.commit = ObjectId.toString(head.objectId)
+            gitInfoMap.abbreviatedId = head.objectId.abbreviate(8).name()
+
+            // Remove any lingering null values
+            gitInfoMap.removeAll { it.value == null }
+
+            final originUrl = getRemotePushUrl(git, "origin")
+
+            return new GitInfo(gitInfoMap, originUrl)
+
+        } catch (RepositoryNotFoundException ignored) {
+            return new GitInfo([
+                    tag          : '0.0',
+                    offset       : '0',
+                    hash         : '00000000',
+                    branch       : 'master',
+                    commit       : '0000000000000000000000',
+                    abbreviatedId: '00000000'
+            ], null)
+        }
+    }
+
+    @Nullable
+    default String getRemotePushUrl(Git git, String remoteName) {
+        def remotes = git.remoteList().call()
+        if (remotes.size() == 0)
+            return null
+
+        // Get the origin remote
+        def originRemote = remotes.toList().stream()
+                .filter(r -> r.getName() == remoteName)
+                .findFirst()
+                .orElse(null)
+
+        //We do not have an origin named remote
+        if (originRemote == null) return null
+
+        // Get the origin push url.
+        def originUrl = originRemote.getURIs().toList().stream()
+                .findFirst()
+                .orElse(null)
+
+        if (originUrl == null) return null // No origin URL
+
+        return transformPushUrl(originUrl.toString())
+    }
+    
+    default String transformPushUrl(String url) {
+        if (url.startsWith("ssh")) {
+            // Convert SSH urls to HTTPS
+            // Check for authentication data (e.g., username:password@example.com)
+            if (url.contains("@")) {
+                // Strip authentication data
+                return "https://" + url.substring(url.indexOf("@") + 1).replace(".git", "")
+            } else {
+                // 'ssh://' is 6 characters
+                return "https://" + url.substring(6).replace(".git", "")
+            }
+        } else if (url.startsWith("http")) {
+            // Already in HTTP(S), so strip the ".git" ending
+            return url.replace(".git", "")
+        }
+
+        // Some other protocol? We don't handle this, so just return the same
+        return url
+    }
+
+    @Immutable
+    class GitInfo {
+        final Map<String, String> gitInfo
+        @Nullable
+        final String originUrl
+    }
+}

--- a/src/main/groovy/net/neoforged/gradleutils/GitInfoValueSource.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GitInfoValueSource.groovy
@@ -23,15 +23,15 @@ import javax.annotation.Nullable
 
 @PackageScope
 @CompileStatic
-interface GitInfoValueSource extends ValueSource<GitInfo, Parameters> {
-    interface Parameters extends ValueSourceParameters {
+abstract class GitInfoValueSource implements ValueSource<GitInfo, Parameters> {
+    static interface Parameters extends ValueSourceParameters {
         DirectoryProperty getWorkingDirectory()
 
         SetProperty<String> getTagFilters()
     }
 
     @Override
-    default GitInfo obtain() {
+    GitInfo obtain() {
         try (Repository repo = new FileRepositoryBuilder().findGitDir(parameters.workingDirectory.get().asFile).build()) {
             final git = Git.wrap(repo)
 
@@ -73,7 +73,7 @@ interface GitInfoValueSource extends ValueSource<GitInfo, Parameters> {
     }
 
     @Nullable
-    default String getRemotePushUrl(Git git, String remoteName) {
+    private static String getRemotePushUrl(Git git, String remoteName) {
         def remotes = git.remoteList().call()
         if (remotes.size() == 0)
             return null
@@ -96,8 +96,8 @@ interface GitInfoValueSource extends ValueSource<GitInfo, Parameters> {
 
         return transformPushUrl(originUrl.toString())
     }
-    
-    default String transformPushUrl(String url) {
+
+    private static String transformPushUrl(String url) {
         if (url.startsWith("ssh")) {
             // Convert SSH urls to HTTPS
             // Check for authentication data (e.g., username:password@example.com)
@@ -118,7 +118,7 @@ interface GitInfoValueSource extends ValueSource<GitInfo, Parameters> {
     }
 
     @Immutable
-    class GitInfo {
+    static class GitInfo {
         final Map<String, String> gitInfo
         @Nullable
         final String originUrl

--- a/src/main/groovy/net/neoforged/gradleutils/GitInfoValueSource.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GitInfoValueSource.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 //file:noinspection UnstableApiUsage
 package net.neoforged.gradleutils
 

--- a/src/main/groovy/net/neoforged/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GradleUtils.groovy
@@ -403,7 +403,7 @@ class GradleUtils {
             // Only setup the CI environment if and only if the environment variables are set.
             final versionProvider = project.provider { project.version?.toString() }
             project.tasks.register("configureTeamCity", ConfigureTeamCity) {
-                version.set(versionProvider)
+                it.version.set(versionProvider)
             }
         }
     }

--- a/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
@@ -42,7 +42,7 @@ abstract class GradleUtilsExtension {
         this.gitRoot = project.objects.directoryProperty().convention(project.layout.projectDirectory)
         this.rawInfo = project.providers.of(GitInfoValueSource) {
             it.parameters {
-                workingDirectory.set(this.gitRoot)
+                it.workingDirectory.set(this.gitRoot)
             }
         }
         this.gitInfo = project.objects.mapProperty(String, String)
@@ -59,8 +59,8 @@ abstract class GradleUtilsExtension {
             filter += '**'
         final valueSource = project.providers.of(GitInfoValueSource) {
             it.parameters {
-                workingDirectory.set(this.gitRoot)
-                tagFilters.add(filter)
+                it.workingDirectory.set(this.gitRoot)
+                it.tagFilters.add(filter)
             }
         }
         return valueSource.get().gitInfo

--- a/src/main/groovy/net/neoforged/gradleutils/tasks/GenerateChangelogTask.java
+++ b/src/main/groovy/net/neoforged/gradleutils/tasks/GenerateChangelogTask.java
@@ -22,6 +22,7 @@ package net.neoforged.gradleutils.tasks;
 
 import net.neoforged.gradleutils.ChangelogUtils;
 import net.neoforged.gradleutils.GradleUtils;
+import net.neoforged.gradleutils.GradleUtilsExtension;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.DirectoryProperty;
@@ -46,7 +47,7 @@ public abstract class GenerateChangelogTask extends DefaultTask
 
     public GenerateChangelogTask()
     {
-        super();
+        final GradleUtilsExtension extension = getProject().getExtensions().getByType(GradleUtilsExtension.class);
 
         //Setup defaults: Using merge-base based text changelog generation of the local project into build/changelog.txt
         getGitDirectory().fileValue(GradleUtils.getGitDirectory(getProject().getProjectDir()));
@@ -54,7 +55,7 @@ public abstract class GenerateChangelogTask extends DefaultTask
         getOutputFile().convention(getProject().getLayout().getBuildDirectory().file("changelog.txt"));
         getStartingCommit().convention("");
         getStartingTag().convention("");
-        getProjectUrl().convention(GradleUtils.buildProjectUrl(getProject().getProjectDir()));
+        getProjectUrl().convention(extension.getOriginUrl());
     }
 
     @InputDirectory

--- a/src/main/groovy/net/neoforged/gradleutils/tasks/GenerateChangelogTask.java
+++ b/src/main/groovy/net/neoforged/gradleutils/tasks/GenerateChangelogTask.java
@@ -21,26 +21,17 @@
 package net.neoforged.gradleutils.tasks;
 
 import net.neoforged.gradleutils.ChangelogUtils;
-import net.neoforged.gradleutils.GradleUtils;
 import net.neoforged.gradleutils.GradleUtilsExtension;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Transformer;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.provider.ProviderInternal;
-import org.gradle.api.internal.provider.TransformBackedProvider;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.publish.maven.MavenArtifact;
-import org.gradle.api.publish.maven.internal.artifact.SingleOutputTaskMavenArtifact;
 import org.gradle.api.tasks.*;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.function.BiFunction;
 
 public abstract class GenerateChangelogTask extends DefaultTask
 {
@@ -50,7 +41,7 @@ public abstract class GenerateChangelogTask extends DefaultTask
         final GradleUtilsExtension extension = getProject().getExtensions().getByType(GradleUtilsExtension.class);
 
         //Setup defaults: Using merge-base based text changelog generation of the local project into build/changelog.txt
-        getGitDirectory().fileValue(GradleUtils.getGitDirectory(getProject().getProjectDir()));
+        getWorkingDirectory().fileValue(getProject().getProjectDir());
         getBuildMarkdown().convention(false);
         getOutputFile().convention(getProject().getLayout().getBuildDirectory().file("changelog.txt"));
         getStartingCommit().convention("");
@@ -60,7 +51,7 @@ public abstract class GenerateChangelogTask extends DefaultTask
 
     @InputDirectory
     @PathSensitive(PathSensitivity.NONE)
-    public abstract DirectoryProperty getGitDirectory();
+    public abstract DirectoryProperty getWorkingDirectory();
 
     @Input
     public abstract Property<Boolean> getBuildMarkdown();
@@ -88,13 +79,13 @@ public abstract class GenerateChangelogTask extends DefaultTask
 
         String changelog = "";
         if (startingCommit.isEmpty() && startingTag.isEmpty()) {
-            changelog = ChangelogUtils.generateChangelog(getGitDirectory().getAsFile().get(), getProjectUrl().get(), !getBuildMarkdown().get());
+            changelog = ChangelogUtils.generateChangelog(getWorkingDirectory().getAsFile().get(), getProjectUrl().get(), !getBuildMarkdown().get());
         }
         else if (startingCommit.isEmpty())  {
-            changelog = ChangelogUtils.generateChangelog(getGitDirectory().getAsFile().get(), getProjectUrl().get(), !getBuildMarkdown().get(), startingTag);
+            changelog = ChangelogUtils.generateChangelog(getWorkingDirectory().getAsFile().get(), getProjectUrl().get(), !getBuildMarkdown().get(), startingTag);
         }
         else {
-            changelog = ChangelogUtils.generateChangelogFromCommit(getGitDirectory().getAsFile().get(), getProjectUrl().get(), !getBuildMarkdown().get(), startingCommit);
+            changelog = ChangelogUtils.generateChangelogFromCommit(getWorkingDirectory().getAsFile().get(), getProjectUrl().get(), !getBuildMarkdown().get(), startingCommit);
         }
 
         final File outputFile = getOutputFile().getAsFile().get();


### PR DESCRIPTION
This PR fixes most incompatibilities with the configuration cache, both in the buildscript of this repository and the GradleUtils plugin, thereby resolving #5.

The main point here is moving any invocation of `Git` during the configuration phase to a `ValueSource`, which Gradle runs outside of the confines of the configuration cache (and therefore the code within can do almost anything, like run processes).

This PR doesn't address invocations of `Git` during task execution, such as done in both of GradleUtils's tasks, as those fall outside of the confines of the configuration cache.

> [!IMPORTANT]
> This PR doesn't fix the uses of `Project` in the `ExtractTeamCityProjectConfigurationTask`, mostly because some of the specifics of that task require access to the `Project` (such as accessing `Project` extensions). Uses of that task should be limited to when the configuration cache is disabled.