### PR TITLE
Improve the error message when there are no Git tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ java {
 }
 
 group 'net.neoforged.gradleutils'
-version '3.0.0-alpha.7'
+version '3.0.0-alpha.8'
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/net/neoforged/gradleutils/VersionCalculator.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/VersionCalculator.groovy
@@ -13,6 +13,7 @@ import org.eclipse.jgit.api.DescribeCommand
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.Repository
+import org.gradle.api.GradleException
 
 import javax.annotation.Nullable
 
@@ -79,6 +80,10 @@ class VersionCalculator {
 
         while (true) {
             final described = describe(git).setTarget(currentRev).call()
+            if (described === null) {
+                throw new GradleException("Cannot calculate the project version without a previous Git tag. Did you forget to run \"git fetch --tags\"?")
+            }
+
             // Describe (long) output is "<tag>-<offset>-g<commit>"
             final describeSplit = GradleUtils.rsplit(described, '-', 2)
 


### PR DESCRIPTION
Previous error message:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because "self" is null
```

New error message:

```
Caused by: org.gradle.api.GradleException: Cannot calculate the project version without a previous Git tag. Did you forget to run "git fetch --tags"?
```