### PR TITLE
Implement a report of all published Maven publications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ java {
 }
 
 group 'net.neoforged.gradleutils'
-version '3.0.0-alpha.8'
+version '3.0.0-alpha.9'
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
@@ -128,6 +128,7 @@ abstract class GradleUtilsExtension {
      * is intended to make it easier to see which version was actually published.
      */
     @Input
+    @DSLProperty
     abstract Property<Boolean> getEnableMavenPublicationSummary();
 
     Object getVersion() {

--- a/src/main/groovy/net/neoforged/gradleutils/ReportMavenPublications.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/ReportMavenPublications.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.gradleutils
+
+import groovy.transform.CompileStatic
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.jetbrains.annotations.NotNull
+
+/**
+ * Implements reporting of published Maven publications at the end of the build.
+ */
+@CompileStatic
+abstract class ReportMavenPublications implements BuildService<Params>, AutoCloseable {
+    private List<Publication> artifacts = Collections.synchronizedList(new ArrayList<>())
+
+    void record(String groupId, String artifactId, String version) {
+        artifacts.add(new Publication(
+                groupId,
+                artifactId,
+                version
+        ))
+    }
+
+    private boolean isEnabled() {
+        return getParameters().getEnabled().getOrElse(false);
+    }
+
+    abstract static class Params implements BuildServiceParameters {
+        abstract Property<Boolean> getEnabled();
+    }
+
+    @Override
+    void close() throws Exception {
+        if (!isEnabled() || artifacts.isEmpty()) {
+            return
+        }
+
+        def sortedArtifacts = new ArrayList<>(artifacts)
+        sortedArtifacts.sort()
+
+        println()
+        println("=" * 80)
+        println(" PUBLISHED MAVEN PUBLICATIONS")
+        println("=" * 80)
+        println()
+        for (final def artifact in sortedArtifacts) {
+            println("  $artifact.groupId:$artifact.artifactId:$artifact.version")
+        }
+        println()
+    }
+
+    private static final class Publication implements Comparable<Publication> {
+        private final String groupId;
+        private final String artifactId;
+        private final String version;
+
+        Publication(String groupId, String artifactId, String version) {
+            this.groupId = groupId
+            this.artifactId = artifactId
+            this.version = version
+        }
+
+        @Override
+        int compareTo(@NotNull Publication o) {
+            return groupId <=> o.groupId ?: artifactId <=> o.artifactId ?: version <=> o.version
+        }
+    }
+}

--- a/src/main/groovy/net/neoforged/gradleutils/ReportMavenPublications.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/ReportMavenPublications.groovy
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull
  */
 @CompileStatic
 abstract class ReportMavenPublications implements BuildService<Params>, AutoCloseable {
-    private List<Publication> artifacts = Collections.synchronizedList(new ArrayList<>())
+    private final List<Publication> artifacts = Collections.synchronizedList(new ArrayList<>())
 
     void record(String groupId, String artifactId, String version) {
         artifacts.add(new Publication(
@@ -49,7 +49,7 @@ abstract class ReportMavenPublications implements BuildService<Params>, AutoClos
         println("=" * 80)
         println()
         for (final def artifact in sortedArtifacts) {
-            println("  $artifact.groupId:$artifact.artifactId:$artifact.version")
+            println("\t$artifact.groupId:$artifact.artifactId:$artifact.version")
         }
         println()
     }


### PR DESCRIPTION
Implement a report of all published Maven publications at the end of the build, with the intention of making it easier to see which version was actually published.

Example output from running publishToMavenLocal on NeoGradle with this PR:

```
[...]
> Task :dsl-platform:publishToMavenLocal

================================================================================
 PUBLISHED MAVEN PUBLICATIONS
================================================================================

  net.neoforged.gradle:common:7.0.66
  net.neoforged.gradle:dsl-common:7.0.66
  net.neoforged.gradle:dsl-mixin:7.0.66
  net.neoforged.gradle:dsl-neoform:7.0.66
  net.neoforged.gradle:dsl-platform:7.0.66
  net.neoforged.gradle:dsl-userdev:7.0.66
  net.neoforged.gradle:dsl-vanilla:7.0.66
  net.neoforged.gradle:mixin:7.0.66
  net.neoforged.gradle:neoform:7.0.66
  net.neoforged.gradle:platform:7.0.66
  net.neoforged.gradle:userdev:7.0.66
  net.neoforged.gradle:utils:7.0.66
  net.neoforged.gradle:vanilla:7.0.66
  net.neoforged.gradle.common:net.neoforged.gradle.common.gradle.plugin:7.0.66
  net.neoforged.gradle.mixin:net.neoforged.gradle.mixin.gradle.plugin:7.0.66
  net.neoforged.gradle.neoform:net.neoforged.gradle.neoform.gradle.plugin:7.0.66
  net.neoforged.gradle.platform:net.neoforged.gradle.platform.gradle.plugin:7.0.66
  net.neoforged.gradle.userdev:net.neoforged.gradle.userdev.gradle.plugin:7.0.66
  net.neoforged.gradle.vanilla:net.neoforged.gradle.vanilla.gradle.plugin:7.0.66

```