### PR TITLE
Fix some configuration cache violations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ sourceSets {
 }
 
 group 'net.neoforged.gradleutils'
-version '3.0.0-alpha.11'
+version '3.0.0-alpha.12'
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
@@ -83,8 +83,13 @@ abstract class GradleUtilsExtension {
         this.gitInfo = objects.mapProperty(String, String)
                 .convention(rawInfo.map { it.gitInfo })
 
-        final possibleSecring = providers.gradleProperty('signing.secretKeyRingFile')
-        shouldSign.convention(project.provider { (System.getenv('GPG_PRIVATE_KEY') || System.getenv('GPG_SUBKEY')) || possibleSecring.getOrNull() })
+        shouldSign.convention(
+                providers.environmentVariable('GPG_PRIVATE_KEY')
+                        .orElse(providers.environmentVariable('GPG_SUBKEY'))
+                        .orElse(providers.gradleProperty('signing.secretKeyRingFile'))
+                        .map { it as boolean }
+                        .orElse(false)
+        )
 
         // Set up reporting of published maven artifacts
         def reportingServiceProvider = project.getGradle().getSharedServices().registerIfAbsent(

--- a/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
@@ -100,7 +100,7 @@ abstract class GradleUtilsExtension {
                 }
         )
         project.tasks.withType(AbstractPublishToMaven).configureEach {
-            configureRecordMavenPublication(it, reportingServiceProvider)
+            configureRecordMavenPublication(it, reportingServiceProvider, providers)
         }
     }
 
@@ -108,12 +108,14 @@ abstract class GradleUtilsExtension {
      * Reconfigures a publish task to record its published publication in the shared build service for
      * generating report at the end of the build.
      */
-    private static void configureRecordMavenPublication(AbstractPublishToMaven configureTask, Provider<ReportMavenPublications> serviceProvider) {
+    private static void configureRecordMavenPublication(AbstractPublishToMaven configureTask, Provider<ReportMavenPublications> serviceProvider, ProviderFactory providerFactory) {
         configureTask.usesService(serviceProvider)
+        Provider<String> groupId = providerFactory.provider {configureTask.publication.groupId}
+        Provider<String> artifactId = providerFactory.provider {configureTask.publication.artifactId}
+        Provider<String> version = providerFactory.provider {configureTask.publication.version}
         configureTask.doLast("recordPublication") { task ->
-            def publication = ((AbstractPublishToMaven) task).publication
             def reportingService = serviceProvider.get()
-            reportingService.record(publication.groupId, publication.artifactId, publication.version)
+            reportingService.record(groupId.get(), artifactId.get(), version.get())
         }
     }
 

--- a/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
@@ -87,7 +87,7 @@ abstract class GradleUtilsExtension {
                 providers.environmentVariable('GPG_PRIVATE_KEY')
                         .orElse(providers.environmentVariable('GPG_SUBKEY'))
                         .orElse(providers.gradleProperty('signing.secretKeyRingFile'))
-                        .map { it as boolean }
+                        .map { true }
                         .orElse(false)
         )
 


### PR DESCRIPTION
This PR fixes two configuration cache violations:
- The `shouldSign` convention no longer has serialization issues
- The maven publication reporting service is now fed proper publication data even when the transient `task.publication` fields are not present when restoring from cache, by capturing the relevant values from them in providers.

Testing locally, this is enough to allow building and locally publishing NeoGradle with configuration caching enabled.