### PR TITLE
Depend on GDI via capability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,11 @@ dependencies {
     api 'org.eclipse.jgit:org.eclipse.jgit:5.10.0.202012080955-r'
     api 'io.github.gradle-nexus:publish-plugin:1.3.0'
 
-    api "net.neoforged:groovydslimprover:${gdi_version}"
-    api "net.neoforged:groovydslimprover:${gdi_version}:base"
-    api "net.neoforged:groovydslimprover:${gdi_version}:runtime"
+    api("net.neoforged:groovydslimprover:${gdi_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:groovydslimprover-base'
+        }
+    }
 
     spotlessImplementation(gradleApi())
     spotlessImplementation 'com.diffplug.spotless:spotless-plugin-gradle:6.23.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-gdi_version=1.0.13
+gdi_version=1.0.15


### PR DESCRIPTION
With GDI 1.0.15, proper capability dependencies are published; depending on GDI via capability allows for gradle to be a bit smarter when picking variants.