### PR TITLE
Add an option to exempt branches matching a regex pattern from suffixing

### DIFF
--- a/src/main/groovy/net/neoforged/gradleutils/VersionCalculator.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/VersionCalculator.groovy
@@ -122,7 +122,7 @@ class VersionCalculator {
         final longBranch = head.symbolic ? head?.target?.name : null
 
         String branch = longBranch != null ? Repository.shortenRefName(longBranch) : ''
-        if (branch in spec.branches.suffixExemptedBranches.get() || spec.branches.suffixExemptedBranchPatterns.any { branch ==~ it }) {
+        if (branch in spec.branches.suffixExemptedBranches.get() || spec.branches.suffixExemptedBranchPatterns.any { branch ==~ /$it/ }) {
             // Branch is exempted from suffix
             return null
         }

--- a/src/main/groovy/net/neoforged/gradleutils/VersionCalculator.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/VersionCalculator.groovy
@@ -122,7 +122,7 @@ class VersionCalculator {
         final longBranch = head.symbolic ? head?.target?.name : null
 
         String branch = longBranch != null ? Repository.shortenRefName(longBranch) : ''
-        if (branch in spec.branches.suffixExemptedBranches.get()) {
+        if (branch in spec.branches.suffixExemptedBranches.get() || spec.branches.suffixExemptedBranchPatterns.any { branch ==~ it }) {
             // Branch is exempted from suffix
             return null
         }

--- a/src/main/groovy/net/neoforged/gradleutils/VersionCalculator.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/VersionCalculator.groovy
@@ -122,7 +122,7 @@ class VersionCalculator {
         final longBranch = head.symbolic ? head?.target?.name : null
 
         String branch = longBranch != null ? Repository.shortenRefName(longBranch) : ''
-        if (branch in spec.branches.suffixExemptedBranches.get() || spec.branches.suffixExemptedBranchPatterns.any { branch ==~ /$it/ }) {
+        if (branch in spec.branches.suffixExemptedBranches.get() || spec.branches.suffixExemptedBranchPatterns.getOrNull()?.any { branch ==~ /$it/ }) {
             // Branch is exempted from suffix
             return null
         }

--- a/src/main/groovy/net/neoforged/gradleutils/specs/VersionBranchesSpec.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/specs/VersionBranchesSpec.groovy
@@ -16,6 +16,8 @@ abstract class VersionBranchesSpec {
     {
         suffixBranch.convention(false)
         suffixExemptedBranches.convention(DEFAULT_ALLOWED_BRANCHES).addAll(DEFAULT_ALLOWED_BRANCHES)
+
+        suffixExemptedBranchPatterns.convention([])
     }
 
     private static final Collection<String> DEFAULT_ALLOWED_BRANCHES = Arrays.asList('', 'main', 'master', 'HEAD')

--- a/src/main/groovy/net/neoforged/gradleutils/specs/VersionBranchesSpec.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/specs/VersionBranchesSpec.groovy
@@ -11,6 +11,8 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 
+import java.util.regex.Pattern
+
 @CompileStatic
 abstract class VersionBranchesSpec {
     {
@@ -26,9 +28,19 @@ abstract class VersionBranchesSpec {
     @DSLProperty
     abstract Property<Boolean> getSuffixBranch();
 
-    // Branch names which are exempted from being suffixed (see suffixBranch above)
-    // Empty string means a situation where the branch cannot be named, for some reason (detached HEAD?)
+    /**
+     * Branch names which are exempted from being suffixed (see suffixBranch above)
+     * Empty string means a situation where the branch cannot be named, for some reason (detached HEAD?)
+     */
     @Input
     @DSLProperty
     abstract SetProperty<String> getSuffixExemptedBranches()
+
+    /**
+     * Branch name patterns which are exempted from being suffixed (see suffixBranch above)
+     * Empty string means a situation where the branch cannot be named, for some reason (detached HEAD?)
+     */
+    @Input
+    @DSLProperty
+    abstract SetProperty<Pattern> getSuffixExemptedBranchPatterns()
 }

--- a/src/main/groovy/net/neoforged/gradleutils/specs/VersionBranchesSpec.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/specs/VersionBranchesSpec.groovy
@@ -11,8 +11,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 
-import java.util.regex.Pattern
-
 @CompileStatic
 abstract class VersionBranchesSpec {
     {
@@ -42,5 +40,5 @@ abstract class VersionBranchesSpec {
      */
     @Input
     @DSLProperty
-    abstract SetProperty<Pattern> getSuffixExemptedBranchPatterns()
+    abstract SetProperty<String> getSuffixExemptedBranchPatterns()
 }


### PR DESCRIPTION
This PR adds a `suffixExemptedBranchPatterns` property containing patterns to test branches against for suffixing in addition to `suffixExemptedBranches`