### PR TITLE
Fix Generic Wildcards for Maven Publishing Repository

### DIFF
--- a/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GradleUtilsExtension.groovy
@@ -150,7 +150,7 @@ abstract class GradleUtilsExtension {
         return versionSpec
     }
 
-    void version(Action<? extends VersionSpec> configureAction) {
+    void version(Action<? super VersionSpec> configureAction) {
         configureAction.execute(versionSpec)
     }
 
@@ -158,13 +158,13 @@ abstract class GradleUtilsExtension {
         return gitInfo.get()
     }
 
-    Action<? extends MavenArtifactRepository> getPublishingMaven(File defaultFolder = rootProjectDir.file('repo').asFile) {
+    Action<MavenArtifactRepository> getPublishingMaven(File defaultFolder = rootProjectDir.file('repo').asFile) {
         return GradleUtils.setupSnapshotCompatiblePublishing(projectVersion, 'https://maven.neoforged.net/releases',
                 defaultFolder, rootProjectDir.file('snapshot').asFile)
     }
 
     @SuppressWarnings('GrMethodMayBeStatic')
-    Action<? extends MavenArtifactRepository> getMaven() {
+    Action<MavenArtifactRepository> getMaven() {
         return GradleUtils.getForgeMaven()
     }
 


### PR DESCRIPTION
The Generic wildcard signatures for getPublishingMaven() and version are incorrect.

Remember the PECS shorthand from Effective Java... Producer Extends, Consumer Super. Paired with returning concrete types instead of wildcard types.

The Action passed to `version` **consumes** a VersionSpec and since it consumes it, the wildcard should be **super**. Reason: An action that consumes an Object is compatible, an action that only consumes specific subclasses of VersionSpec is **not** compatible (but our current signature simply ignores that).

The Action returned by `getPublishingMaven` cannot legally be used from Java code, since it's actually unknown what specific subtype of MavenRepository it supports. It has to either return `Action<? super MavenRepository>` *or* preferrably return the concrete type it supports.

This fixes this for consumers of the library:
```java
var publications = project.getExtensions().getByType(PublishingExtension.class);
publications.getRepositories().maven(gradleUtilsExtension.getPublishingMaven()); // This currently does not compile
```

Since this is clearly a bug for consumers of the library, take that into consideration for deciding whether this is a breaking change ;-)
Anyone passing an `Action<MySubclassOfVersionSpec>` will already crash at runtime. And anyone respecting the Java type system cannot make use of `getPublishingMaven`.
