### PR TITLE
Fix How Default Repository URIs Are Created

### DIFF
--- a/src/main/groovy/net/neoforged/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/neoforged/gradleutils/GradleUtils.groovy
@@ -136,9 +136,9 @@ class GradleUtils {
                 }
             } else {
                 if (version.endsWith("-SNAPSHOT")) {
-                    it.url = 'file://' + defaultSnapshotFolder.getAbsolutePath()
+                    it.url = defaultSnapshotFolder.getAbsoluteFile().toURI()
                 } else {
-                    it.url = 'file://' + defaultFolder.getAbsolutePath()
+                    it.url = defaultFolder.getAbsoluteFile().toURI()
                 }
             }
         }


### PR DESCRIPTION
Should fix issues like this with CC enabled:

```
Caused by: org.gradle.api.InvalidUserDataException: Cannot convert URI 'file://Z:\NeoForm\repo' to a file.
	at org.gradle.api.internal.file.FileNotationConverter.convert(FileNotationConverter.java:101)
```